### PR TITLE
add non-root user by default for best practice

### DIFF
--- a/10/debian-10/Dockerfile
+++ b/10/debian-10/Dockerfile
@@ -11,3 +11,6 @@ ENV BITNAMI_APP_NAME="bitnami-shell" \
     OS_FLAVOUR="debian-10" \
     OS_NAME="linux"
 
+RUN echo "nobody:x:1000:1000:nobody:/:/bin/sh" >> /etc/passwd
+RUN echo "nobody:x:1000:" >> /etc/group
+USER 1000


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

**Description of the change**

Adds a `nobody` and defaults to running as that when the container is started.

**Benefits**

* security best practice
* when running in Kubernetes, no need to specify `securityContext`

**Possible drawbacks**

If someone wanted to install other tools and need root they wouldn't be able to.

**Applicable issues**

* None that I'm aware of

**Additional information**

Adapts best practices from https://docs.bitnami.com/tutorials/bitnami-best-practices-hardening-containers/#root-and-non-root-containers
